### PR TITLE
Bug: Agent unable to hear supervisor during coaching

### DIFF
--- a/functions/functions/coaching.js
+++ b/functions/functions/coaching.js
@@ -30,6 +30,7 @@ exports.handler = TokenValidator(async (context, event, callback) => {
     const participantResponse = await client.conferences(conferenceSid).participants(participantSid).update({
       coaching,
       callSidToCoach: agentSid,
+      muted: coaching ? false : true,
     });
     response.setBody({
       status: 200,


### PR DESCRIPTION
This PR resolves an issue that when a supervisor initiates coaching with an agent they are unable to be heard by the agent. This is due to the supervisor participant being muted.

This change explicitly sets the muted property for the supervisor on beginning a coaching session, allowing them to be heard by the agent. The Supervisor will still not be heard by the customer unless barge in is then enabled. This closes #25 